### PR TITLE
Added the ability to distinguish between command and regular handle method

### DIFF
--- a/src/telegram_bot/bot.cr
+++ b/src/telegram_bot/bot.cr
@@ -103,7 +103,14 @@ module TelegramBot
     def handle_update(u)
       if msg = u.message
         return if !allowed_user?(msg)
-        handle msg
+        if @cmd_handler_included && is_command?(msg)
+          res = handle_command msg
+          if !res
+            handle msg
+          end
+        else
+          handle msg
+        end
       elsif query = u.inline_query
         return if !allowed_user?(query)
         handle query
@@ -129,6 +136,10 @@ module TelegramBot
 
     protected def logger : Logger
       @logger ||= Logger.new(STDOUT).tap { |l| l.level = Logger::DEBUG }
+    end
+
+    private def is_command?(msg) : Bool
+      !!(msg.text && msg.text.not_nil![0] == '/')
     end
 
     private def allowed_user?(msg) : Bool

--- a/src/telegram_bot/cmd_handler.cr
+++ b/src/telegram_bot/cmd_handler.cr
@@ -2,6 +2,7 @@ module TelegramBot
   module CmdHandler
     macro included
       @commands = {} of String => (TelegramBot::Message ->) | (TelegramBot::Message, Array(String) ->)
+      @cmd_handler_included = true
     end
 
     def /(command : String, &block : Message ->)
@@ -33,7 +34,7 @@ module TelegramBot
       end
     end
 
-    def handle(message : Message)
+    private def handle_command(message : Message)
       if txt = message.text || message.caption
         if txt[0] == '/'
           a = txt.gsub(/\s+/m, ' ').gsub(/^\s+|\s+$/m, "").split(' ')
@@ -51,8 +52,10 @@ module TelegramBot
           end
 
           call cmd, message, a[1..-1]
+          return true
         end
       end
+      false
     end
   end
 end


### PR DESCRIPTION
This fixes #23. May not be the best possible fix, but the general idea is sound. I modified the `handle` method in `CmdHandler` making it private and changing it's name to `handle_command`, then added a check in the `handle_update` method to check if the message is a command.