### PR TITLE
fix delete_method

### DIFF
--- a/src/telegram_bot/bot.cr
+++ b/src/telegram_bot/bot.cr
@@ -549,10 +549,10 @@ module TelegramBot
       end
     end
 
-    def delete_message(char_id : Int | String,
+    def delete_message(chat_id : Int | String,
                        message_id : Int32) : Message | Bool | Nil
       res = def_request "deleteMessage", chat_id, message_id
-      if res == "True"
+      if res == true
         return true
       else
         Message.from_json res.to_json if res


### PR DESCRIPTION
char_id => chat_id typo fix

and for some reason, `def_request` returned a boolean anyways, so the strict string compare broke stuff

could possibly do `res.as_bool`, but I'm not familiar enough with Crystal yet to be confident that won't blow up.