### PR TITLE
Updated post_form to work with the new post(form: ...) syntax

### DIFF
--- a/src/telegram_bot/http_client.cr
+++ b/src/telegram_bot/http_client.cr
@@ -12,7 +12,7 @@ module TelegramBot
     end
 
     def post_form(method : String, params : Hash)
-      HTTP::Client.post_form(url_for(method), params)
+      HTTP::Client.post(url_for(method), form: params)
     end
 
     def post_multipart(method : String, params)


### PR DESCRIPTION
Fixes at least one issue with crystal 0.24. May close #26 