### PR TITLE
Fix typization in get_chat_administrators function

### DIFF
--- a/src/telegram_bot/bot.cr
+++ b/src/telegram_bot/bot.cr
@@ -533,7 +533,7 @@ module TelegramBot
 
     def get_chat_administrators(chat_id : Int | String)
       res = def_request "getChatAdministrators", chat_id
-      res = res.not_nil!
+      res = res.not_nil!.as_a
       admins = Array(ChatMember).new
       res.each { |m| admins << ChatMember.from_json(m.to_json) }
       admins


### PR DESCRIPTION
In crystal 0.26.0 current setup gives error: undefined method 'each' for JSON::Any, so we should type cast this to array.