### PR TITLE
Fix method name error

### DIFF
--- a/src/telegram_bot/cmd_handler.cr
+++ b/src/telegram_bot/cmd_handler.cr
@@ -35,8 +35,8 @@ module TelegramBot
 
     def handle(message : Message)
       if txt = message.text || message.caption
-        return unless txt.stats_with? '/'
-  
+        return unless txt.starts_with? '/'
+
         a = txt.gsub(/\s+/m, ' ').gsub(/^\s+|\s+$/m, "").split(' ')
         cmd = a[0][1..-1]
 


### PR DESCRIPTION
`String#starts_with` is not `String#stats_with`, which causes compilation errors, undefined methods